### PR TITLE
Fixed Linux Authentication Issue using PSCore 7.0.0+ on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       osx_image: xcode9.1
       before_install:
         - brew update
-        - brew tap caskroom/cask
+        - brew tap homebrew/cask
         - brew cask install powershell
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode9.1
+      osx_image: xcode11.6
       addons:
         homebrew:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ matrix:
     - os: osx
       osx_image: xcode9.1
       before_install:
-        - brew update
         - brew cask install powershell
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ matrix:
   include:
     - os: osx
       osx_image: xcode9.1
-      before_install:
-        - brew cask install powershell
+      addons:
+        homebrew:
+          packages:
+          - powershell
+          update: true
     - os: linux
       dist: trusty
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ matrix:
       osx_image: xcode9.1
       before_install:
         - brew update
-        - brew tap homebrew/cask
         - brew cask install powershell
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ matrix:
   include:
     - os: osx
       osx_image: xcode11.6
-      addons:
-        homebrew:
-          packages:
-          - powershell
-          update: true
+      before_install:
+        - brew update
+        - brew tap homebrew/cask
+        - brew cask install powershell
     - os: linux
       dist: trusty
       services:

--- a/src/lib/Get-JenkinsCrumb.ps1
+++ b/src/lib/Get-JenkinsCrumb.ps1
@@ -26,8 +26,7 @@ function Get-JenkinsCrumb
         $Username = $Credential.Username
 
         # Decrypt the secure string password
-        $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Credential.Password)
-        $Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+        $Password = $Credential.GetNetworkCredential().Password
 
         $Bytes = [System.Text.Encoding]::UTF8.GetBytes($Username + ':' + $Password)
         $Base64Bytes = [System.Convert]::ToBase64String($Bytes)

--- a/src/lib/Invoke-JenkinsCommand.ps1
+++ b/src/lib/Invoke-JenkinsCommand.ps1
@@ -79,8 +79,7 @@ function Invoke-JenkinsCommand
         $username = $Credential.Username
 
         # Decrypt the secure string password
-        $passwordBstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Credential.Password)
-        $password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($passwordBstr)
+        $password = $Credential.GetNetworkCredential().Password
 
         $authorizationBytes = [System.Text.Encoding]::UTF8.GetBytes($username + ':' + $password)
         $authorizationBytesBase64 = [System.Convert]::ToBase64String($authorizationBytes)


### PR DESCRIPTION
# Pull Request

## Bug Fixes

This will fix the flawed method for decrypting the Jenkins password which is broken using PSCore 7.0.0+ on Linux. Discussion around this can be found [here](https://github.com/PowerShell/PowerShell/issues/12114)

- Fixes #5 


@PlagueHO let me know if there's anything I've missed 😃

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plagueho/jenkins/6)
<!-- Reviewable:end -->
